### PR TITLE
Fix for user attributes not encoded properly.

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
-  gem.add_runtime_dependency     'net-ldap', '~> 0.11'
+  gem.add_runtime_dependency     'net-ldap', '~> 0.12.1'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.3'
   gem.add_runtime_dependency     'rubyntlm', '~> 0.5'
   gem.add_development_dependency 'rspec', '~> 2.14'


### PR DESCRIPTION
Net::LDAP has a problem with non-ascii characters, see 
https://github.com/ruby-ldap/ruby-net-ldap/pull/242

That PR has been merged to Net::LDAP 0.13.0 but at the same time they have dropped support for <2.0 Ruby, so made this workaround to keep support for older Rubies still.
